### PR TITLE
Remove dependency on Governor's LifecycleMethods

### DIFF
--- a/fabricator-core/build.gradle
+++ b/fabricator-core/build.gradle
@@ -4,10 +4,15 @@ dependencies {
     compile     'com.google.code.findbugs:annotations:2.0.0'
     compile     "com.fasterxml.jackson.core:jackson-core:2.4.1"
     compile     "com.fasterxml.jackson.core:jackson-databind:2.4.1"
-    compile     "com.netflix.governator:governator:1.15.1"
+    compile     "com.netflix.governator:governator:1.14.3"
     compile     'commons-codec:commons-codec:1.3'
     compile     'org.slf4j:slf4j-api:1.7.2'
     compile     'commons-lang:commons-lang:2.6'
+    
+    compile     "javax.inject:javax.inject:1"
+    compile     "com.google.inject:guice:4.1.0"
+    compile     "com.google.inject.extensions:guice-multibindings:4.1.0"
+    compile     "com.google.inject.extensions:guice-grapher:4.1.0"    // should be provided - only if you want graphing
 
     testCompile 'junit:junit:4.11'
     testCompile 'org.mockito:mockito-core:1.8.5'


### PR DESCRIPTION
Also revert to governator 1.14.4.  Governator 1.15 has a backwards incompatible change and fabricator shouldn't contribute adding it as a dependency.
